### PR TITLE
Enh/adding jwt auth

### DIFF
--- a/.idea/backend.iml
+++ b/.idea/backend.iml
@@ -26,7 +26,7 @@
       </configuration>
     </facet>
   </component>
-  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_8">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_12">
     <output url="file://$MODULE_DIR$/target/classes" />
     <output-test url="file://$MODULE_DIR$/target/test-classes" />
     <content url="file://$MODULE_DIR$">

--- a/.idea/backend.iml
+++ b/.idea/backend.iml
@@ -8,7 +8,9 @@
       <configuration>
         <setting name="validation-enabled" value="true" />
         <setting name="provider-name" value="Hibernate" />
-        <datasource-mapping />
+        <datasource-mapping>
+          <factory-entry name="entityManagerFactory" />
+        </datasource-mapping>
         <naming-strategy-map />
       </configuration>
     </facet>
@@ -38,59 +40,7 @@
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
-    <orderEntry type="library" name="Maven: com.h2database:h2:1.4.200" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-data-jpa:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-aop:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-aop:5.2.4.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.aspectj:aspectjweaver:1.9.5" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-jdbc:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: com.zaxxer:HikariCP:3.4.2" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-jdbc:5.2.4.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: jakarta.activation:jakarta.activation-api:1.2.2" level="project" />
-    <orderEntry type="library" name="Maven: jakarta.persistence:jakarta.persistence-api:2.2.3" level="project" />
-    <orderEntry type="library" name="Maven: jakarta.transaction:jakarta.transaction-api:1.3.3" level="project" />
-    <orderEntry type="library" name="Maven: org.hibernate:hibernate-core:5.4.12.Final" level="project" />
-    <orderEntry type="library" name="Maven: org.jboss.logging:jboss-logging:3.4.1.Final" level="project" />
-    <orderEntry type="library" name="Maven: org.javassist:javassist:3.24.0-GA" level="project" />
-    <orderEntry type="library" name="Maven: net.bytebuddy:byte-buddy:1.10.8" level="project" />
-    <orderEntry type="library" name="Maven: antlr:antlr:2.7.7" level="project" />
-    <orderEntry type="library" name="Maven: org.jboss:jandex:2.1.1.Final" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml:classmate:1.5.1" level="project" />
-    <orderEntry type="library" name="Maven: org.dom4j:dom4j:2.1.1" level="project" />
-    <orderEntry type="library" name="Maven: org.hibernate.common:hibernate-commons-annotations:5.1.0.Final" level="project" />
-    <orderEntry type="library" name="Maven: org.glassfish.jaxb:jaxb-runtime:2.3.2" level="project" />
-    <orderEntry type="library" name="Maven: org.glassfish.jaxb:txw2:2.3.2" level="project" />
-    <orderEntry type="library" name="Maven: com.sun.istack:istack-commons-runtime:3.0.8" level="project" />
-    <orderEntry type="library" name="Maven: org.jvnet.staxex:stax-ex:1.8.1" level="project" />
-    <orderEntry type="library" name="Maven: com.sun.xml.fastinfoset:FastInfoset:1.2.16" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.data:spring-data-jpa:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.data:spring-data-commons:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-orm:5.2.4.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-context:5.2.4.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-expression:5.2.4.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-tx:5.2.4.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-beans:5.2.4.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.30" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-aspects:5.2.4.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-webflux:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-autoconfigure:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-logging:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: ch.qos.logback:logback-classic:1.2.3" level="project" />
-    <orderEntry type="library" name="Maven: ch.qos.logback:logback-core:1.2.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-to-slf4j:2.12.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-api:2.12.1" level="project" />
-    <orderEntry type="library" name="Maven: org.slf4j:jul-to-slf4j:1.7.30" level="project" />
-    <orderEntry type="library" name="Maven: jakarta.annotation:jakarta.annotation-api:1.3.5" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Maven: org.yaml:snakeyaml:1.25" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-json:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.10.2" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-annotations:2.10.2" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.10.2" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.10.2" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.2" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.module:jackson-module-parameter-names:2.10.2" level="project" />
     <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-reactor-netty:2.2.5.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: io.projectreactor.netty:reactor-netty:0.9.5.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: io.netty:netty-codec-http:4.1.45.Final" level="project" />
@@ -106,45 +56,9 @@
     <orderEntry type="library" name="Maven: io.netty:netty-transport-native-epoll:linux-x86_64:4.1.45.Final" level="project" />
     <orderEntry type="library" name="Maven: io.netty:netty-transport-native-unix-common:4.1.45.Final" level="project" />
     <orderEntry type="library" name="Maven: org.glassfish:jakarta.el:3.0.3" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-validation:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: jakarta.validation:jakarta.validation-api:2.0.2" level="project" />
-    <orderEntry type="library" name="Maven: org.hibernate.validator:hibernate-validator:6.0.18.Final" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-web:5.2.4.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.springframework:spring-webflux:5.2.4.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.synchronoss.cloud:nio-multipart-parser:1.1.0" level="project" />
     <orderEntry type="library" name="Maven: org.synchronoss.cloud:nio-stream-storage:1.1.3" level="project" />
-    <orderEntry type="library" scope="PROVIDED" name="Maven: org.projectlombok:lombok:1.18.12" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.springframework.boot:spring-boot-starter-test:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.springframework.boot:spring-boot-test:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.springframework.boot:spring-boot-test-autoconfigure:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: com.jayway.jsonpath:json-path:2.4.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: net.minidev:json-smart:2.3" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: net.minidev:accessors-smart:1.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.ow2.asm:asm:5.0.4" level="project" />
-    <orderEntry type="library" name="Maven: jakarta.xml.bind:jakarta.xml.bind-api:2.3.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter:5.5.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-api:5.5.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.apiguardian:apiguardian-api:1.1.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.opentest4j:opentest4j:1.2.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-commons:1.5.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-params:5.5.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.jupiter:junit-jupiter-engine:5.5.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.junit.platform:junit-platform-engine:1.5.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-junit-jupiter:3.1.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.assertj:assertj-core:3.13.2" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest:2.1" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:3.1.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: net.bytebuddy:byte-buddy-agent:1.10.8" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:2.6" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.skyscreamer:jsonassert:1.5.0" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: com.vaadin.external.google:android-json:0.0.20131108.vaadin1" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-core:5.2.4.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-jcl:5.2.4.RELEASE" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.springframework:spring-test:5.2.4.RELEASE" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: org.xmlunit:xmlunit-core:2.6.3" level="project" />
-    <orderEntry type="library" scope="TEST" name="Maven: io.projectreactor:reactor-test:3.3.3.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: io.projectreactor:reactor-core:3.3.3.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.reactivestreams:reactive-streams:1.0.3" level="project" />
     <orderEntry type="library" name="Maven: com.h2database:h2:1.4.200" level="project" />
     <orderEntry type="library" name="Maven: io.springfox:springfox-swagger2:2.9.2" level="project" />
     <orderEntry type="library" name="Maven: io.swagger:swagger-annotations:1.5.20" level="project" />
@@ -161,10 +75,29 @@
     <orderEntry type="library" name="Maven: org.springframework.plugin:spring-plugin-core:1.2.0.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.springframework:spring-beans:5.2.4.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.springframework:spring-context:5.2.4.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-aop:5.2.4.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.springframework.plugin:spring-plugin-metadata:1.2.0.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.mapstruct:mapstruct:1.2.0.Final" level="project" />
     <orderEntry type="library" name="Maven: io.springfox:springfox-swagger-ui:2.9.2" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-security:2.2.5.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter:2.2.5.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot:2.2.5.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-autoconfigure:2.2.5.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-logging:2.2.5.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: ch.qos.logback:logback-classic:1.2.3" level="project" />
+    <orderEntry type="library" name="Maven: ch.qos.logback:logback-core:1.2.3" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-to-slf4j:2.12.1" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-api:2.12.1" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:jul-to-slf4j:1.7.30" level="project" />
+    <orderEntry type="library" name="Maven: jakarta.annotation:jakarta.annotation-api:1.3.5" level="project" />
+    <orderEntry type="library" scope="RUNTIME" name="Maven: org.yaml:snakeyaml:1.25" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework:spring-aop:5.2.4.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.security:spring-security-config:5.2.2.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.security:spring-security-core:5.2.2.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework.security:spring-security-web:5.2.2.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: org.springframework:spring-expression:5.2.4.RELEASE" level="project" />
+    <orderEntry type="library" name="Maven: io.jsonwebtoken:jjwt:0.9.1" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.10.2" level="project" />
+    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.10.2" level="project" />
     <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-data-jpa:2.2.5.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-aop:2.2.5.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.aspectj:aspectjweaver:1.9.5" level="project" />
@@ -193,20 +126,7 @@
     <orderEntry type="library" name="Maven: org.springframework:spring-tx:5.2.4.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.springframework:spring-aspects:5.2.4.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-web:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-autoconfigure:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-logging:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: ch.qos.logback:logback-classic:1.2.3" level="project" />
-    <orderEntry type="library" name="Maven: ch.qos.logback:logback-core:1.2.3" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-to-slf4j:2.12.1" level="project" />
-    <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-api:2.12.1" level="project" />
-    <orderEntry type="library" name="Maven: org.slf4j:jul-to-slf4j:1.7.30" level="project" />
-    <orderEntry type="library" name="Maven: jakarta.annotation:jakarta.annotation-api:1.3.5" level="project" />
-    <orderEntry type="library" scope="RUNTIME" name="Maven: org.yaml:snakeyaml:1.25" level="project" />
     <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-json:2.2.5.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-databind:2.10.2" level="project" />
-    <orderEntry type="library" name="Maven: com.fasterxml.jackson.core:jackson-core:2.10.2" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.10.2" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.10.2" level="project" />
     <orderEntry type="library" name="Maven: com.fasterxml.jackson.module:jackson-module-parameter-names:2.10.2" level="project" />
@@ -219,7 +139,7 @@
     <orderEntry type="library" name="Maven: org.hibernate.validator:hibernate-validator:6.0.18.Final" level="project" />
     <orderEntry type="library" name="Maven: org.springframework:spring-web:5.2.4.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.springframework:spring-webmvc:5.2.4.RELEASE" level="project" />
-    <orderEntry type="library" name="Maven: org.springframework:spring-expression:5.2.4.RELEASE" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: org.projectlombok:lombok:1.18.12" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.springframework.boot:spring-boot-starter-test:2.2.5.RELEASE" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.springframework.boot:spring-boot-test:2.2.5.RELEASE" level="project" />
     <orderEntry type="library" scope="TEST" name="Maven: org.springframework.boot:spring-boot-test-autoconfigure:2.2.5.RELEASE" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,17 @@
 			<version>2.9.2</version>
 		</dependency>
 
+<!--		AUTHENTICATION-->
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt</artifactId>
+			<version>0.9.1</version>
+		</dependency>
+
 <!--		SPRING-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/vanhalen/config/SecurityConfig.java
+++ b/src/main/java/com/vanhalen/config/SecurityConfig.java
@@ -1,12 +1,63 @@
 package com.vanhalen.config;
 
+import com.vanhalen.filters.JwtRequestFilter;
+import com.vanhalen.logic.authentication.DefaultUserDetailsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
 @EnableWebSecurity
-public class SecurityConfig extends WebSecurityConfiguration {
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private DefaultUserDetailsService _userDefaultUserDetailsService;
+    private JwtRequestFilter _jwtRequestFilter;
+
+    @Autowired
+    public SecurityConfig(DefaultUserDetailsService defaultUserDetailsService, JwtRequestFilter jwtRequestFilter) {
+        _userDefaultUserDetailsService = defaultUserDetailsService;
+        _jwtRequestFilter = jwtRequestFilter;
+    }
+
+    @Override
+    @Bean
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    @Override
+    protected void configure(AuthenticationManagerBuilder auth) throws Exception {
+        auth.userDetailsService(_userDefaultUserDetailsService)
+                .passwordEncoder(passwordEncoder());
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http.csrf().disable()
+                .authorizeRequests().antMatchers("/api/user/auth",
+                "/swagger-ui.html", "/v2/api-docs/**", "/swagger.json", "/swagger-resources/**",
+                "/webjars", "/h2/**").permitAll()
+                .anyRequest().authenticated()
+                .and().sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
+        http.addFilterBefore(_jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);
+        http.headers().frameOptions().disable();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
 }

--- a/src/main/java/com/vanhalen/config/SecurityConfig.java
+++ b/src/main/java/com/vanhalen/config/SecurityConfig.java
@@ -1,0 +1,12 @@
+package com.vanhalen.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfiguration;
+
+@Configuration
+@EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
+@EnableWebSecurity
+public class SecurityConfig extends WebSecurityConfiguration {
+}

--- a/src/main/java/com/vanhalen/config/SwaggerConfig.java
+++ b/src/main/java/com/vanhalen/config/SwaggerConfig.java
@@ -29,7 +29,7 @@ public class SwaggerConfig {
                 .securityContexts(Lists.newArrayList(securityContext()))
                 .securitySchemes(Lists.newArrayList(apiKey()))
                 .select()
-                .apis(RequestHandlerSelectors.basePackage("com.vanhalen.api.controllers"))
+                .apis(RequestHandlerSelectors.basePackage("com.vanhalen.endpoints"))
                 .paths(PathSelectors.any())
                 .build()
                 .pathMapping("/")

--- a/src/main/java/com/vanhalen/domain/Skittle.java
+++ b/src/main/java/com/vanhalen/domain/Skittle.java
@@ -3,14 +3,23 @@ package com.vanhalen.domain;
 import lombok.Getter;
 
 import javax.persistence.Entity;
+import javax.persistence.Id;
 import java.awt.*;
+import java.util.UUID;
 
 @Entity
 @Getter
 public class Skittle {
+    @Id
+    private UUID id;
+
     private Color color;
 
     public Skittle(Color color) {
         this.color = color;
+    }
+
+    public Skittle() {
+
     }
 }

--- a/src/main/java/com/vanhalen/domain/User.java
+++ b/src/main/java/com/vanhalen/domain/User.java
@@ -1,0 +1,23 @@
+package com.vanhalen.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import java.util.UUID;
+
+@Entity
+@Getter
+public class User {
+
+    @Id
+    @Getter
+    private UUID id;
+
+    @Getter @Setter
+    private String userName;
+
+    @Getter @Setter
+    private String password;
+}

--- a/src/main/java/com/vanhalen/domain/User.java
+++ b/src/main/java/com/vanhalen/domain/User.java
@@ -2,22 +2,64 @@ package com.vanhalen.domain;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.annotations.GenericGenerator;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import javax.persistence.*;
+import java.util.Collection;
 import java.util.UUID;
 
 @Entity
 @Getter
-public class User {
+@Setter
+@Table(name = "users")
+public class User implements UserDetails {
 
     @Id
-    @Getter
+    @GeneratedValue(generator = "UUID")
+    @GenericGenerator(name = "UUID", strategy = "org.hibernate.id.UUIDGenerator")
+    @Column(name = "id", unique = true, nullable = false)
     private UUID id;
 
-    @Getter @Setter
+    @Column(name = "username", unique = true, nullable = false)
     private String userName;
 
-    @Getter @Setter
+    @Column(name = "password", nullable = false)
     private String password;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return userName;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 }

--- a/src/main/java/com/vanhalen/endpoints/UserController.java
+++ b/src/main/java/com/vanhalen/endpoints/UserController.java
@@ -1,4 +1,52 @@
 package com.vanhalen.endpoints;
 
+import com.vanhalen.endpoints.viewmodels.auth.AuthRequestViewModel;
+import com.vanhalen.interfaces.AuthLogicInterface;
+import com.vanhalen.interfaces.UserLogicInterface;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/user")
+@Api(tags = {"User management"})
+@ApiResponses(value = {
+        @ApiResponse(code = 200, message = "Successfully executed request"),
+        @ApiResponse(code = 400, message = "Failed to execute request"),
+        @ApiResponse(code = 401, message = "Unauthorized: Invalid username or password"),
+        @ApiResponse(code = 403, message = "Unauthorized: No access to resource"),
+        @ApiResponse(code = 404, message = "Resource not found")
+})
 public class UserController {
+
+    private UserLogicInterface _userLogic;
+    private AuthLogicInterface _authLogic;
+
+    @Autowired
+    public UserController(UserLogicInterface userLogic, AuthLogicInterface authLogic) {
+        _userLogic = userLogic;
+        _authLogic = authLogic;
+    }
+
+    @ApiOperation(value = "Use username and password to obtain JWT bearer token", response = String.class)
+    @PostMapping("/auth")
+    public ResponseEntity authenticate(@RequestBody AuthRequestViewModel authRequestViewModel) {
+        try {
+            var bearerToken = _authLogic.authenticate(authRequestViewModel.getUsername(), authRequestViewModel.getPassword());
+            return ResponseEntity.status(HttpStatus.OK).body(bearerToken);
+        } catch (AuthenticationException ex) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Username or password is incorrect");
+        } catch (Exception ex) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+        }
+    }
 }

--- a/src/main/java/com/vanhalen/endpoints/UserController.java
+++ b/src/main/java/com/vanhalen/endpoints/UserController.java
@@ -1,0 +1,4 @@
+package com.vanhalen.endpoints;
+
+public class UserController {
+}

--- a/src/main/java/com/vanhalen/endpoints/viewmodels/auth/AuthRequestViewModel.java
+++ b/src/main/java/com/vanhalen/endpoints/viewmodels/auth/AuthRequestViewModel.java
@@ -1,0 +1,15 @@
+package com.vanhalen.endpoints.viewmodels.auth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AuthRequestViewModel {
+    @JsonProperty("username")
+    private String username;
+
+    @JsonProperty("password")
+    private String password;
+}

--- a/src/main/java/com/vanhalen/filters/JwtRequestFilter.java
+++ b/src/main/java/com/vanhalen/filters/JwtRequestFilter.java
@@ -1,0 +1,53 @@
+package com.vanhalen.filters;
+
+import com.vanhalen.logic.authentication.DefaultUserDetailsService;
+import com.vanhalen.logic.authentication.JwtService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtRequestFilter extends OncePerRequestFilter {
+
+    private JwtService _jwtService;
+    private DefaultUserDetailsService _userDetailsService;
+
+    @Autowired
+    public JwtRequestFilter(JwtService jwtService, DefaultUserDetailsService defaultUserDetailsService) {
+        _jwtService = jwtService;
+        _userDetailsService = defaultUserDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest httpServletRequest, HttpServletResponse httpServletResponse, FilterChain filterChain) throws ServletException, IOException {
+        final String authHeader = httpServletRequest.getHeader("Authorization");
+
+        var email = "";
+        var jwtToken = "";
+
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            jwtToken = authHeader.substring(7);
+            email = _jwtService.extractEmail(jwtToken);
+        }
+
+        if (email != "") {
+            var userDetails = _userDetailsService.loadUserByUsername(email);
+            if (_jwtService.validateJwtToken(jwtToken, userDetails)) {
+                var usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                usernamePasswordAuthenticationToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(httpServletRequest));
+                SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+            }
+        }
+        filterChain.doFilter(httpServletRequest, httpServletResponse);
+    }
+}

--- a/src/main/java/com/vanhalen/interfaces/AuthLogicInterface.java
+++ b/src/main/java/com/vanhalen/interfaces/AuthLogicInterface.java
@@ -1,0 +1,5 @@
+package com.vanhalen.interfaces;
+
+public interface AuthLogicInterface {
+    String authenticate(String username, String password);
+}

--- a/src/main/java/com/vanhalen/interfaces/UserLogicInterface.java
+++ b/src/main/java/com/vanhalen/interfaces/UserLogicInterface.java
@@ -1,0 +1,4 @@
+package com.vanhalen.interfaces;
+
+public interface UserLogicInterface {
+}

--- a/src/main/java/com/vanhalen/interfaces/UserLogicInterface.java
+++ b/src/main/java/com/vanhalen/interfaces/UserLogicInterface.java
@@ -1,4 +1,9 @@
 package com.vanhalen.interfaces;
 
+import com.vanhalen.domain.User;
+
+import java.util.Optional;
+
 public interface UserLogicInterface {
+    Optional<User> findByUserName(String userName);
 }

--- a/src/main/java/com/vanhalen/logic/UserLogic.java
+++ b/src/main/java/com/vanhalen/logic/UserLogic.java
@@ -1,8 +1,27 @@
 package com.vanhalen.logic;
 
+import com.vanhalen.domain.User;
 import com.vanhalen.interfaces.UserLogicInterface;
+import com.vanhalen.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 public class UserLogic implements UserLogicInterface {
+
+
+    private UserRepository _userRepository;
+
+    @Autowired
+    public UserLogic(UserRepository userRepository) {
+
+        _userRepository = userRepository;
+    }
+
+    @Override
+    public Optional<User> findByUserName(String userName) {
+        return _userRepository.findByUserName(userName);
+    }
 }

--- a/src/main/java/com/vanhalen/logic/UserLogic.java
+++ b/src/main/java/com/vanhalen/logic/UserLogic.java
@@ -1,0 +1,8 @@
+package com.vanhalen.logic;
+
+import com.vanhalen.interfaces.UserLogicInterface;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserLogic implements UserLogicInterface {
+}

--- a/src/main/java/com/vanhalen/logic/authentication/AuthLogic.java
+++ b/src/main/java/com/vanhalen/logic/authentication/AuthLogic.java
@@ -1,0 +1,32 @@
+package com.vanhalen.logic.authentication;
+
+import com.vanhalen.interfaces.AuthLogicInterface;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class AuthLogic implements AuthLogicInterface {
+    private AuthenticationManager _authAuthenticationManager;
+    private JwtService _jwtService;
+    private DefaultUserDetailsService _userDetailsService;
+
+    @Autowired
+    public AuthLogic(AuthenticationManager authenticationManager, DefaultUserDetailsService defaultUserDetailsService, JwtService jwtService) {
+        _authAuthenticationManager = authenticationManager;
+        _userDetailsService = defaultUserDetailsService;
+        _jwtService = jwtService;
+    }
+
+    @Override
+    public String authenticate(String username, String password) throws AuthenticationException {
+        _authAuthenticationManager.authenticate(new UsernamePasswordAuthenticationToken(username, password));
+
+        final var user = _userDetailsService.loadUserByUsername(username);
+
+        return _jwtService.generateJwtToken(user);
+    }
+}

--- a/src/main/java/com/vanhalen/logic/authentication/DefaultUserDetailsService.java
+++ b/src/main/java/com/vanhalen/logic/authentication/DefaultUserDetailsService.java
@@ -1,0 +1,25 @@
+package com.vanhalen.logic.authentication;
+
+import com.vanhalen.interfaces.UserLogicInterface;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DefaultUserDetailsService implements UserDetailsService {
+
+    private UserLogicInterface _userLogic;
+
+    @Autowired
+    public DefaultUserDetailsService(UserLogicInterface userLogic) {
+        _userLogic = userLogic;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String userName) throws UsernameNotFoundException {
+        var user = _userLogic.findByUserName(userName);
+        return user.orElseThrow();
+    }
+}

--- a/src/main/java/com/vanhalen/logic/authentication/JwtService.java
+++ b/src/main/java/com/vanhalen/logic/authentication/JwtService.java
@@ -1,0 +1,53 @@
+package com.vanhalen.logic.authentication;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+@Service
+public class JwtService {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    public String extractEmail(String token) {
+        return extractClaimFromToken(token, Claims::getSubject);
+    }
+
+    public Date extractExpiration(String token) {
+        return extractClaimFromToken(token, Claims::getExpiration);
+    }
+
+    private <T> T extractClaimFromToken(String token, Function<Claims, T> claimsResolver) {
+        final Claims claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
+        return claimsResolver.apply(claims);
+    }
+
+    private boolean isTokenExpired(String token) {
+        return extractExpiration(token).before(new Date());
+    }
+
+    public String generateJwtToken(UserDetails userDetails) {
+        Map<String, Object> claims = new HashMap<>();
+        return createJwtToken(claims, userDetails.getUsername());
+    }
+
+    private String createJwtToken(Map<String, Object> claims, String subject) {
+        return Jwts.builder().setClaims(claims).setSubject(subject).setIssuedAt(new Date(System.currentTimeMillis()))
+                .setExpiration(new Date(System.currentTimeMillis() + 1000*60*60*10))
+                .signWith(SignatureAlgorithm.HS256, secretKey).compact();
+    }
+
+    public boolean validateJwtToken(String token, UserDetails userDetails) {
+        final String email = extractEmail(token);
+        return (email.equals(userDetails.getUsername()) && !isTokenExpired(token));
+    }
+}

--- a/src/main/java/com/vanhalen/main/MainApplication.java
+++ b/src/main/java/com/vanhalen/main/MainApplication.java
@@ -2,10 +2,14 @@ package com.vanhalen.main;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
-@ComponentScan(basePackages = {"com.vanhalen.config"})
+@ComponentScan(basePackages = {"com.vanhalen.filters", "com.vanhalen.config", "com.vanhalen.logic", "com.vanhalen.endpoints"})
+@EntityScan({"com.vanhalen.domain"})
+@EnableJpaRepositories({"com.vanhalen.repositories"})
 public class MainApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/vanhalen/repositories/UserRepository.java
+++ b/src/main/java/com/vanhalen/repositories/UserRepository.java
@@ -4,8 +4,10 @@ import com.vanhalen.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 @Repository
-public abstract class UserRepository implements JpaRepository<User, UUID> {
+public interface UserRepository extends JpaRepository<User, UUID> {
+    Optional<User> findByUserName(String userName);
 }

--- a/src/main/java/com/vanhalen/repositories/UserRepository.java
+++ b/src/main/java/com/vanhalen/repositories/UserRepository.java
@@ -1,0 +1,11 @@
+package com.vanhalen.repositories;
+
+import com.vanhalen.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public abstract class UserRepository implements JpaRepository<User, UUID> {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
+jwt.secret="testSecret"
 
+spring.jpa.hibernate.ddl-auto=none

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,1 @@
+INSERT INTO users VALUES ( '0095aec6-6213-4fc7-ad70-539a17ff39e1', 'admin', '$2a$10$lk5fTyCawQcVTxEO3l8k4OI3qAGhuQf8L/lAo1FaEBMDlacgNCBx.')

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,7 @@
+Drop table if Exists users;
+
+CREATE table users  (
+    id UUID primary key,
+    username varchar not null unique,
+    password varchar not null
+);


### PR DESCRIPTION
Added Jwt bearer token authentication. Send post with json body : 
{
  "username": "string",
  "password": "string"
}
to /api/user/auth.

Returns 401 on bad credentials and return 200 with bearer token (string) on correct credentials.

Use bearer token in authorization header to authenticate on every other endpoint.

- [x] Add User entity, logic and controller

- [x] Add default user "admin"

- [x] Add authentication functionality