### PR TITLE
Enh/add mqtt client

### DIFF
--- a/.idea/backend.iml
+++ b/.idea/backend.iml
@@ -59,6 +59,7 @@
     <orderEntry type="library" name="Maven: org.springframework:spring-webflux:5.2.4.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.synchronoss.cloud:nio-multipart-parser:1.1.0" level="project" />
     <orderEntry type="library" name="Maven: org.synchronoss.cloud:nio-stream-storage:1.1.3" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.2" level="project" />
     <orderEntry type="library" name="Maven: com.h2database:h2:1.4.200" level="project" />
     <orderEntry type="library" name="Maven: io.springfox:springfox-swagger2:2.9.2" level="project" />
     <orderEntry type="library" name="Maven: io.swagger:swagger-annotations:1.5.20" level="project" />

--- a/.idea/backend.iml
+++ b/.idea/backend.iml
@@ -78,6 +78,7 @@
     <orderEntry type="library" name="Maven: org.springframework.plugin:spring-plugin-metadata:1.2.0.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.mapstruct:mapstruct:1.2.0.Final" level="project" />
     <orderEntry type="library" name="Maven: io.springfox:springfox-swagger-ui:2.9.2" level="project" />
+    <orderEntry type="library" name="Maven: org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.2" level="project" />
     <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter-security:2.2.5.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot-starter:2.2.5.RELEASE" level="project" />
     <orderEntry type="library" name="Maven: org.springframework.boot:spring-boot:2.2.5.RELEASE" level="project" />

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,13 @@
 			<version>2.9.2</version>
 		</dependency>
 
+<!--		MQTT-->
+		<dependency>
+			<groupId>org.eclipse.paho</groupId>
+			<artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+			<version>1.2.2</version>
+		</dependency>
+
 <!--		AUTHENTICATION-->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/src/main/java/com/vanhalen/config/SecurityConfig.java
+++ b/src/main/java/com/vanhalen/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests().antMatchers("/api/user/auth",
                 "/swagger-ui.html", "/v2/api-docs/**", "/swagger.json", "/swagger-resources/**",
                 "/webjars", "/h2/**").permitAll()
-                .anyRequest().authenticated()
+                //.anyRequest().authenticated()
                 .and().sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS);
         http.addFilterBefore(_jwtRequestFilter, UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/vanhalen/endpoints/SkittleController.java
+++ b/src/main/java/com/vanhalen/endpoints/SkittleController.java
@@ -1,13 +1,38 @@
 package com.vanhalen.endpoints;
 
-import com.vanhalen.logic.SkittleLogic;
+import com.vanhalen.interfaces.SkittleLogicInterface;
+import com.vanhalen.interfaces.MqttServiceInterface;
+import io.swagger.annotations.ApiOperation;
+import org.eclipse.paho.client.mqttv3.MqttException;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("skittles/")
+@RequestMapping("api/skittles")
 public class SkittleController {
+
+    private SkittleLogicInterface _skittleLogic;
+    private MqttServiceInterface _mqttService;
+
     @Autowired
-    private SkittleLogic logic;
+    public SkittleController(SkittleLogicInterface skittleLogic, MqttServiceInterface mqttService){
+        _skittleLogic = skittleLogic;
+        _mqttService = mqttService;
+    }
+
+    @ApiOperation(value = "Use username and password to obtain JWT bearer token", response = String.class)
+    @PostMapping("/sort")
+    public ResponseEntity SortSkittles(@RequestBody String color){
+        try{
+            _mqttService.publishMessage("/VanHalen/color", String.valueOf(color).getBytes());
+            return ResponseEntity.status(HttpStatus.OK).body("Mqtt message sent");
+        } catch (MqttException ex) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+        } catch (Exception ex) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(ex.getMessage());
+        }
+
+    }
 }

--- a/src/main/java/com/vanhalen/interfaces/MqttServiceInterface.java
+++ b/src/main/java/com/vanhalen/interfaces/MqttServiceInterface.java
@@ -1,4 +1,4 @@
-package com.vanhalen.messaging;
+package com.vanhalen.interfaces;
 
 import org.eclipse.paho.client.mqttv3.MqttException;
 

--- a/src/main/java/com/vanhalen/main/MainApplication.java
+++ b/src/main/java/com/vanhalen/main/MainApplication.java
@@ -7,7 +7,7 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
-@ComponentScan(basePackages = {"com.vanhalen.filters", "com.vanhalen.config", "com.vanhalen.logic", "com.vanhalen.endpoints"})
+@ComponentScan(basePackages = {"com.vanhalen.filters", "com.vanhalen.config", "com.vanhalen.logic", "com.vanhalen.endpoints", "com.vanhalen.messaging"})
 @EntityScan({"com.vanhalen.domain"})
 @EnableJpaRepositories({"com.vanhalen.repositories"})
 public class MainApplication {

--- a/src/main/java/com/vanhalen/messaging/MqttService.java
+++ b/src/main/java/com/vanhalen/messaging/MqttService.java
@@ -5,27 +5,30 @@ import org.eclipse.paho.client.mqttv3.IMqttClient;
 import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
-import java.util.UUID;
 
 import static org.eclipse.paho.client.mqttv3.MqttException.REASON_CODE_CLIENT_NOT_CONNECTED;
 
 @Service
 public class MqttService implements MqttServiceInterface {
 
-    private final String publisherId = UUID.randomUUID().toString();
-    private final IMqttClient _mqttClient;
 
-    public MqttService() throws MqttException {
-        _mqttClient = new MqttClient("tcp://localhost:1883", publisherId);
-        _mqttClient.connect();
+    private IMqttClient _mqttClient;
+
+    public MqttService(@Value("${mqtt.client.host-url}") String mqttHostUrl, @Value("${mqtt.client.publisher-id}") String publisherId) throws MqttException {
+        try {
+            _mqttClient = new MqttClient(mqttHostUrl, publisherId);
+            _mqttClient.connect();
+        } catch (MqttException ex) {
+            //TODO action when unable to connect to host URL
+        }
+
     }
 
     public void publishMessage(String topic, byte[] payload) throws MqttException {
         if (!_mqttClient.isConnected()) throw new MqttException(REASON_CODE_CLIENT_NOT_CONNECTED);
         var mqttMessage = new MqttMessage(payload);
-        mqttMessage.setRetained(true);
         mqttMessage.setQos(2);
         _mqttClient.publish(topic, mqttMessage);
     }

--- a/src/main/java/com/vanhalen/messaging/MqttService.java
+++ b/src/main/java/com/vanhalen/messaging/MqttService.java
@@ -1,0 +1,28 @@
+package com.vanhalen.messaging;
+
+import org.eclipse.paho.client.mqttv3.IMqttClient;
+import org.eclipse.paho.client.mqttv3.MqttClient;
+import org.eclipse.paho.client.mqttv3.MqttException;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+
+import java.util.UUID;
+
+import static org.eclipse.paho.client.mqttv3.MqttException.REASON_CODE_CLIENT_NOT_CONNECTED;
+
+public class MqttService implements MqttServiceInterface{
+
+    private final String publisherId = UUID.randomUUID().toString();
+    private final IMqttClient _mqttClient;
+
+    public MqttService() throws MqttException {
+        _mqttClient = new MqttClient("tcp://localhost:8080", publisherId);
+        _mqttClient.connect();
+    }
+
+    public void publishMessage(String topic, byte[] payload) throws MqttException {
+        if (!_mqttClient.isConnected()) throw new MqttException(REASON_CODE_CLIENT_NOT_CONNECTED);
+        var mqttMessage = new MqttMessage(payload);
+        mqttMessage.setRetained(true);
+        _mqttClient.publish(topic, mqttMessage);
+    }
+}

--- a/src/main/java/com/vanhalen/messaging/MqttService.java
+++ b/src/main/java/com/vanhalen/messaging/MqttService.java
@@ -1,21 +1,24 @@
 package com.vanhalen.messaging;
 
+import com.vanhalen.interfaces.MqttServiceInterface;
 import org.eclipse.paho.client.mqttv3.IMqttClient;
 import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.springframework.stereotype.Service;
 
 import java.util.UUID;
 
 import static org.eclipse.paho.client.mqttv3.MqttException.REASON_CODE_CLIENT_NOT_CONNECTED;
 
-public class MqttService implements MqttServiceInterface{
+@Service
+public class MqttService implements MqttServiceInterface {
 
     private final String publisherId = UUID.randomUUID().toString();
     private final IMqttClient _mqttClient;
 
     public MqttService() throws MqttException {
-        _mqttClient = new MqttClient("tcp://localhost:8080", publisherId);
+        _mqttClient = new MqttClient("tcp://localhost:1883", publisherId);
         _mqttClient.connect();
     }
 
@@ -23,6 +26,7 @@ public class MqttService implements MqttServiceInterface{
         if (!_mqttClient.isConnected()) throw new MqttException(REASON_CODE_CLIENT_NOT_CONNECTED);
         var mqttMessage = new MqttMessage(payload);
         mqttMessage.setRetained(true);
+        mqttMessage.setQos(2);
         _mqttClient.publish(topic, mqttMessage);
     }
 }

--- a/src/main/java/com/vanhalen/messaging/MqttServiceInterface.java
+++ b/src/main/java/com/vanhalen/messaging/MqttServiceInterface.java
@@ -1,0 +1,7 @@
+package com.vanhalen.messaging;
+
+import org.eclipse.paho.client.mqttv3.MqttException;
+
+public interface MqttServiceInterface {
+    void publishMessage(String topic, byte[] payload) throws MqttException;
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 jwt.secret="testSecret"
+mqtt.client.host-url=tcp://localhost:1883
+mqtt.client.publisher-id=vanHalen-backend
 
 spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
Added Mqtt client as a service.

- [x] Add MqttService 

- [x] Create endpoint for testing Mqtt

- [x] Put mqtt variables inside application.property file 

To test Mqtt connection, point `mqtt.client.host-url` inside application.properties` to a working message broker and send a http post request to `/skittles/sort` with a single string inside of the body. This send that value via mqtt to the topic `/vanHalen/color`.